### PR TITLE
Exception handling refactor minor fix - explicitly requiring base_error.rb as the rails dependency loading fails here

### DIFF
--- a/lib/wepay_client.rb
+++ b/lib/wepay_client.rb
@@ -3,6 +3,7 @@ require 'wepay_client/client'
 require 'wepay_client/account'
 require 'wepay_client/checkout'
 require 'wepay_client/preapproval'
+require 'wepay_client/base_error'
 require 'wepay_client/exceptions'
 
 

--- a/lib/wepay_client/base_error.rb
+++ b/lib/wepay_client/base_error.rb
@@ -1,15 +1,17 @@
-class BaseError < StandardError
-
-  def initialize(message = '', code = nil)
-    @error_message = message
-    @error_code = code
-  end
-
-  def message
-    @error_message
-  end
-
-  def code
-    @error_code.to_s
+module WepayClient
+  class BaseError < StandardError
+  
+    def initialize(message = '', code = nil)
+      @error_message = message
+      @error_code = code
+    end
+  
+    def message
+      @error_message
+    end
+  
+    def code
+      @error_code.to_s
+    end
   end
 end


### PR DESCRIPTION
Exception handling refactor minor fix - explicitly requiring base_error.rb as the rails dependency loading fails here
